### PR TITLE
feat: ナビゲーション改善とOGPメタタグの実装

### DIFF
--- a/components/navbar.tsx
+++ b/components/navbar.tsx
@@ -148,9 +148,9 @@ const Navbar = (props: any) => {
                     <LinkItem href="company" path={path}>
                         Company
                     </LinkItem>
-                    <LinkItem href="recruit" path={path}>
+                    <PageLinkItem href="/recruit" path={path}>
                         Recruit
-                    </LinkItem>
+                    </PageLinkItem>
                     <ContactLinkItem
                         href="https://forms.gle/HJXsrsk5myVrmEqC6"
                         path={path}
@@ -186,7 +186,7 @@ const Navbar = (props: any) => {
                                 <MenuItem as={HambItem} href="company">
                                     Company
                                 </MenuItem>
-                                <MenuItem as={HambItem} href="recruit">
+                                <MenuItem as={NextLink} href="/recruit">
                                     Recruit
                                 </MenuItem>
                                 <MenuItem as={MenuLink} href="https://forms.gle/HJXsrsk5myVrmEqC6">

--- a/pages/en/index.tsx
+++ b/pages/en/index.tsx
@@ -70,8 +70,18 @@ const Home = ({ newPosts }: Props) => {
     return (
         <Layout>
             <Head>
-                <meta name="description" content="Nefront Inc. develops indoor AR cloud service" />
-                <title>Nefront Inc.</title>
+                <title>Nefront Inc. - Connecting building information with physical locations</title>
+                <meta name="description" content="Nefront connects building information with physical locations and visualizes it intuitively with AI and AR technologies" />
+                <meta property="og:title" content="Nefront Inc." />
+                <meta property="og:description" content="Nefront connects building information with physical locations and visualizes it intuitively with AI and AR technologies" />
+                <meta property="og:type" content="website" />
+                <meta property="og:url" content="https://www.nefront.com/en" />
+                <meta property="og:image" content="https://www.nefront.com/images/ogp/nefront-ogp-en.png" />
+                <meta property="og:locale" content="en_US" />
+                <meta name="twitter:card" content="summary_large_image" />
+                <meta name="twitter:title" content="Nefront Inc." />
+                <meta name="twitter:description" content="Nefront connects building information with physical locations and visualizes it intuitively with AI and AR technologies" />
+                <meta name="twitter:image" content="https://www.nefront.com/images/ogp/nefront-ogp-en.png" />
             </Head>
             <Container maxW="99999999px">
                 <div id="top" />

--- a/pages/filefront.tsx
+++ b/pages/filefront.tsx
@@ -1,5 +1,6 @@
 import { url } from 'lib/img';
 import React, { useEffect, useRef } from 'react';
+import Head from 'next/head';
 import ReactGA from 'react-ga4';
 import { Box, Container, Heading } from '@chakra-ui/react';
 import Layout from '@/layouts/article';
@@ -43,6 +44,20 @@ const Filefront = () => {
 
     return (
         <Layout>
+            <Head>
+                <title>Filefront - AI図面管理ツール | Nefront Inc.</title>
+                <meta name="description" content="PDFの図面の中身まで簡単に検索できるシステム。PDFの中身までOCRで解析して検索。さらにページ毎にAIがタグ付けして条件検索も。" />
+                <meta property="og:title" content="Filefront - AI図面管理ツール | Nefront Inc." />
+                <meta property="og:description" content="PDFの図面の中身まで簡単に検索できるシステム。PDFの中身までOCRで解析して検索。さらにページ毎にAIがタグ付けして条件検索も。" />
+                <meta property="og:type" content="website" />
+                <meta property="og:url" content="https://www.nefront.com/filefront" />
+                <meta property="og:image" content="https://www.nefront.com/images/ogp/filefront-ogp.png" />
+                <meta property="og:locale" content="ja_JP" />
+                <meta name="twitter:card" content="summary_large_image" />
+                <meta name="twitter:title" content="Filefront - AI図面管理ツール | Nefront Inc." />
+                <meta name="twitter:description" content="PDFの図面の中身まで簡単に検索できるシステム。PDFの中身までOCRで解析して検索。さらにページ毎にAIがタグ付けして条件検索も。" />
+                <meta name="twitter:image" content="https://www.nefront.com/images/ogp/filefront-ogp.png" />
+            </Head>
             <Container maxW="1200px">
                 <div
                     style={{

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -2,6 +2,7 @@ import { url } from 'lib/img';
 import { getNewPosts } from 'lib/posts';
 import dynamic from 'next/dynamic';
 import Link from 'next/link';
+import Head from 'next/head';
 import React, { useEffect, useRef } from 'react';
 import ReactGA from 'react-ga4';
 import { Post } from 'types/posts';
@@ -68,6 +69,20 @@ const Home = ({ newPosts }: Props) => {
 
     return (
         <Layout>
+            <Head>
+                <title>Nefront Inc. - AIやAR技術により、建物の情報をわかりやすく見える化</title>
+                <meta name="description" content="AIやAR技術により、建物の情報をわかりやすく見える化します" />
+                <meta property="og:title" content="Nefront Inc." />
+                <meta property="og:description" content="AIやAR技術により、建物の情報をわかりやすく見える化します" />
+                <meta property="og:type" content="website" />
+                <meta property="og:url" content="https://www.nefront.com/" />
+                <meta property="og:image" content="https://www.nefront.com/images/ogp/nefront-ogp.png" />
+                <meta property="og:locale" content="ja_JP" />
+                <meta name="twitter:card" content="summary_large_image" />
+                <meta name="twitter:title" content="Nefront Inc." />
+                <meta name="twitter:description" content="AIやAR技術により、建物の情報をわかりやすく見える化します" />
+                <meta name="twitter:image" content="https://www.nefront.com/images/ogp/nefront-ogp.png" />
+            </Head>
             <Container maxW="99999999px">
                 <div id="top" />
                 <div id="parent">
@@ -283,7 +298,7 @@ const Home = ({ newPosts }: Props) => {
                         Recruit
                     </Heading>
                     <p style={{ textAlign: 'center', margin: '10px' }}>
-                        Nefrontと一緒に、より良い未来を創造する仲間を募集しています
+                        Nefrontで共に「欲しい情報が欲しい時に目の前にある世界の実現」を目指す、仲間を募集しています。
                     </p>
                     <div style={{ display: 'flex', justifyContent: 'center', marginTop: '2rem' }}>
                         <Link href="/recruit" className="more">

--- a/pages/indooar.tsx
+++ b/pages/indooar.tsx
@@ -1,5 +1,6 @@
 import { url } from 'lib/img';
 import React from 'react';
+import Head from 'next/head';
 import ReactGA from 'react-ga4';
 import { Box, Container, Heading } from '@chakra-ui/react';
 import Layout from '@/layouts/article';
@@ -13,6 +14,20 @@ ReactGA.send('pageview');
 const IndooAR = () => {
     return (
         <Layout>
+            <Head>
+                <title>IndooAR - 屋内空間情報管理システム | Nefront Inc.</title>
+                <meta name="description" content="屋内空間に情報を紐付けて、空間的に情報を管理できるシステム。画像認識や位置マーカーにより建物内の位置情報を特定し、現場で簡単に位置情報付きで作業を記録。" />
+                <meta property="og:title" content="IndooAR - 屋内空間情報管理システム | Nefront Inc." />
+                <meta property="og:description" content="屋内空間に情報を紐付けて、空間的に情報を管理できるシステム。画像認識や位置マーカーにより建物内の位置情報を特定し、現場で簡単に位置情報付きで作業を記録。" />
+                <meta property="og:type" content="website" />
+                <meta property="og:url" content="https://www.nefront.com/indooar" />
+                <meta property="og:image" content="https://www.nefront.com/images/ogp/indooar-ogp.png" />
+                <meta property="og:locale" content="ja_JP" />
+                <meta name="twitter:card" content="summary_large_image" />
+                <meta name="twitter:title" content="IndooAR - 屋内空間情報管理システム | Nefront Inc." />
+                <meta name="twitter:description" content="屋内空間に情報を紐付けて、空間的に情報を管理できるシステム。画像認識や位置マーカーにより建物内の位置情報を特定し、現場で簡単に位置情報付きで作業を記録。" />
+                <meta name="twitter:image" content="https://www.nefront.com/images/ogp/indooar-ogp.png" />
+            </Head>
             <Container maxW="1200px">
                 <div
                     style={{

--- a/pages/recruit.tsx
+++ b/pages/recruit.tsx
@@ -1,5 +1,6 @@
 import { url } from 'lib/img';
 import React, { useState } from 'react';
+import Head from 'next/head';
 import ReactGA from 'react-ga4';
 import { Box, Container, Heading, SimpleGrid } from '@chakra-ui/react';
 import Layout from '@/layouts/article';
@@ -15,6 +16,20 @@ const Recruit = () => {
     
     return (
         <Layout>
+            <Head>
+                <title>採用情報 - Nefront Inc.</title>
+                <meta name="description" content="AIやAR技術により、建物の情報をわかりやすく見える化するためのシステムを開発しています。Nefrontで共に「欲しい情報が欲しい時に目の前にある世界の実現」を目指す、仲間を募集しています。" />
+                <meta property="og:title" content="採用情報 - Nefront Inc." />
+                <meta property="og:description" content="AIやAR技術により、建物の情報をわかりやすく見える化するためのシステムを開発しています。Nefrontで共に「欲しい情報が欲しい時に目の前にある世界の実現」を目指す、仲間を募集しています。" />
+                <meta property="og:type" content="website" />
+                <meta property="og:url" content="https://www.nefront.com/recruit" />
+                <meta property="og:image" content="https://www.nefront.com/images/ogp/recruit-ogp.png" />
+                <meta property="og:locale" content="ja_JP" />
+                <meta name="twitter:card" content="summary_large_image" />
+                <meta name="twitter:title" content="採用情報 - Nefront Inc." />
+                <meta name="twitter:description" content="AIやAR技術により、建物の情報をわかりやすく見える化するためのシステムを開発しています。Nefrontで共に「欲しい情報が欲しい時に目の前にある世界の実現」を目指す、仲間を募集しています。" />
+                <meta name="twitter:image" content="https://www.nefront.com/images/ogp/recruit-ogp.png" />
+            </Head>
             <Container maxW="1200px">
                 <div style={{ width: '100%', height: '80px' }} />
 


### PR DESCRIPTION
## Summary
- リクルートページへの直接ナビゲーションを実装
- 全ページにOGPメタタグを追加してSNSシェア機能を改善
- トップページのリクルートセクションの文言を更新

## 変更内容

### ナビゲーション改善
- ナビゲーションバーのRecruitリンクを`#recruit`から`/recruit`への直接リンクに変更

### OGPメタタグの実装
各ページにOpen Graph ProtocolとTwitter Cardのメタタグを追加

### 文言更新
- トップページのリクルートセクション: 「Nefrontで共に「欲しい情報が欲しい時に目の前にある世界の実現」を目指す、仲間を募集しています。」

🤖 Generated with [Claude Code](https://claude.ai/code)